### PR TITLE
Update PKGBUILD

### DIFF
--- a/qtox-git/PKGBUILD
+++ b/qtox-git/PKGBUILD
@@ -24,7 +24,7 @@ makedepends=('git' 'qt5-tools')
 provides=("$_pkgname")
 conflicts=("$_pkgname")
 install=$pkgname.install
-source=("$_pkgname::git+https://github.com/tux3/qTox.git")
+source=("$_pkgname::git+https://github.com/tux3/qTox.git#branch=back_in_the_game")
 sha512sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
using branch "back_in_the_game", which uses new API, compiles and runs fine if libvpx error is handled by soft linking to existing library... don't know how to fix that otherwise...
